### PR TITLE
env vars must override file values

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -58,7 +58,7 @@ export const build = async (file, args) => {
   const fileOptions = await fetchFileConfig(file) || {}
   const argOptions = pick(args, ['token', 'project', 'output'])
 
-  const options = { ...envOptions, ...fileOptions, ...argOptions }
+  const options = { ...fileOptions, ...envOptions, ...argOptions }
 
   try {
     validate(options)

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -37,6 +37,21 @@ describe('config', () => {
       })
     })
 
+    it('env values override file values', async () => {
+      expect.assertions(1)
+
+      process.env.LOKALISE_TOKEN = 'test_token_env'
+      process.env.LOKALISE_PROJECT = 'test_project_env'
+      process.env.LOKALISE_OUTPUT = 'test_output_env'
+      const conf = await config.build('fixtures/.lokalise.json', { })
+
+      expect(conf).toEqual({
+        token: 'test_token_env',
+        project: 'test_project_env',
+        output: 'test_output_env'
+      })
+    })
+
     it('loads all option config values', async () => {
       expect.assertions(1)
 


### PR DESCRIPTION
Hi,

I'd like to be able to override values in file with en var : file is used for dev purpose and env vars for deployment (I do not use the same project in dev and prod) 

Thanks !