### PR TITLE
cleanup nock state after test suite run

### DIFF
--- a/src/download.test.js
+++ b/src/download.test.js
@@ -19,6 +19,7 @@ describe('download', () => {
     })
 
     afterAll(() => {
+      nock.cleanAll()
       nock.enableNetConnect()
     })
 

--- a/src/request.test.js
+++ b/src/request.test.js
@@ -45,6 +45,7 @@ describe('request', () => {
     })
 
     afterAll(() => {
+      nock.cleanAll()
       nock.enableNetConnect()
     })
 


### PR DESCRIPTION
seemingly nock state was interfering with subsequent test runs.