### PR TITLE
Change deprecated endpoint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+## How to try a development build of Lokalise in another project
+
+To link `lokalise` on the command line to `bin/lokalise.js` in a development build:
+
+```sh-session
+$ cd /path/to/your/Lokalise_clone
+$ yarn link
+```
+
+To build Lokalise:
+
+```sh-session
+$ cd /path/to/your/Lokalise_clone
+
+$ yarn build
+```
+
+To run tests in another project with the development build of Lokalise:
+
+```sh-session
+$ cd /path/to/another/project
+
+# link development build to the other project
+$ yarn link lokalise
+
+$ yarn lokalise
+```
+
+
+To unlink `lokalise` on the command line from `bin/lokalise.js` in a development build:
+
+```sh
+yarn unlink lokalise
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,17 @@
+## Formatting & linting
+This project formats its source code using Standard JS. You can use `--fix` to automatically format your code
+
+```ssh-session
+yarn lint --fix
+```
+
+
+## Running Tests
+
+```sh-session
+yarn test
+```
+
 ## How to try a development build of Lokalise in another project
 
 To link `lokalise` on the command line to `bin/lokalise.js` in a development build:

--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ You can configure the format of the keys file to suit your needs by passing the 
   flow: [boolean] (optional, default false) if true adds a //@flow annotation at the top so that the keys can be used with flow type checking
 }
 ```
+
+## Contributing
+
+Thanks for wanting to contribute! Take a look at our [Contributing Guide](CONTRIBUTING.md) for notes and how to run tests.

--- a/src/download.js
+++ b/src/download.js
@@ -1,8 +1,8 @@
 import request from 'request'
 import unzpr from 'unzip-stream'
 
-export const archive = (filename, outputPath) => new Promise((resolve, reject) => {
-  const req = request.get(`https://s3-eu-west-1.amazonaws.com/lokalise-assets/${filename}`)
+export const archive = (fileUrl, outputPath) => new Promise((resolve, reject) => {
+  const req = request.get(fileUrl)
     .on('response', function (response) {
       if (response.statusCode >= 400) {
         req.destroy()

--- a/src/download.test.js
+++ b/src/download.test.js
@@ -6,10 +6,13 @@ import fs from 'fs-extra'
 import path from 'path'
 
 const outputDir = 'output_test'
+const baseUrl = 'https://s3-eu-west-1.amazonaws.com'
+const pathUrl = '/lokalise-assets/test.zip'
+const fullUrl = `${baseUrl}${pathUrl}`
 
 const mockTransaction = () => (
-  nock('https://s3-eu-west-1.amazonaws.com')
-    .get('/lokalise-assets/test.zip')
+  nock(baseUrl)
+    .get(pathUrl)
 )
 
 describe('download', () => {
@@ -37,7 +40,7 @@ describe('download', () => {
         { 'Content-Type': 'application/octet-stream' }
       )
 
-      await download.archive('test.zip', outputDir)
+      await download.archive(fullUrl, outputDir)
 
       expect(fs.existsSync(outputDir)).toEqual(true)
       expect(fs.readdirSync(outputDir)).toEqual(expect.arrayContaining([
@@ -59,21 +62,21 @@ describe('download', () => {
         { 'Content-Type': 'application/octet-stream' }
       )
 
-      await expect(download.archive('test.zip', outputDir)).rejects.toBeInstanceOf(Error)
+      await expect(download.archive(fullUrl, outputDir)).rejects.toBeInstanceOf(Error)
     })
 
     it('throws when response has non successful code', async () => {
       expect.assertions(1)
       mockTransaction().reply(400, 'Not Found')
 
-      await expect(download.archive('test.zip', outputDir)).rejects.toBeInstanceOf(Error)
+      await expect(download.archive(fullUrl, outputDir)).rejects.toBeInstanceOf(Error)
     })
 
     it('throws when response has non zip content-type', async () => {
       expect.assertions(1)
       mockTransaction().reply(200, 'Not a zip file!', { 'Content-Type': 'text/plain' })
 
-      await expect(download.archive('test.zip', outputDir)).rejects.toBeInstanceOf(Error)
+      await expect(download.archive(fullUrl, outputDir)).rejects.toBeInstanceOf(Error)
     })
   })
 })

--- a/src/request.js
+++ b/src/request.js
@@ -3,13 +3,15 @@ import request from 'request'
 export const bundle = (apiToken, projectId) => new Promise((resolve, reject) => (
   request
     .post({
-      url: 'https://lokalise.co/api/project/export',
-      form: {
-        api_token: apiToken,
-        id: projectId,
-        type: 'json',
-        bundle_filename: '%PROJECT_NAME%-intl.zip',
-        bundle_structure: '%LANG_ISO%.%FORMAT%'
+      url: `https://api.lokalise.com/api2/projects/${projectId}/files/download`,
+      json: true,
+      body: {
+        "format": "json",
+        "original_filenames": true
+      },
+      headers: {
+        'x-api-token': apiToken,
+        'content-type': 'application/json'
       }
     },
     async (err, httpResponse, body) => {
@@ -19,10 +21,6 @@ export const bundle = (apiToken, projectId) => new Promise((resolve, reject) => 
       if (httpResponse.statusCode >= 400) {
         return reject(Error(`HTTP Error ${httpResponse.statusCode}`))
       }
-      const parsed = await JSON.parse(body)
-      if (parsed.response.status === 'error') {
-        return reject(Error(body))
-      }
-      resolve(parsed.bundle.file)
+      resolve(body.bundle_url)
     })
 ))

--- a/src/request.js
+++ b/src/request.js
@@ -6,8 +6,10 @@ export const bundle = (apiToken, projectId) => new Promise((resolve, reject) => 
       url: `https://api.lokalise.com/api2/projects/${projectId}/files/download`,
       json: true,
       body: {
-        "format": "json",
-        "original_filenames": true
+        format: 'json',
+        original_filenames: false,
+        bundle_filename: '%PROJECT_NAME%-intl.zip',
+        bundle_structure: '%LANG_ISO%.%FORMAT%'
       },
       headers: {
         'x-api-token': apiToken,
@@ -21,6 +23,10 @@ export const bundle = (apiToken, projectId) => new Promise((resolve, reject) => 
       if (httpResponse.statusCode >= 400) {
         return reject(Error(`HTTP Error ${httpResponse.statusCode}`))
       }
+      if (body.response && body.response.status === 'error') {
+        return reject(Error(body))
+      }
+
       resolve(body.bundle_url)
     })
 ))

--- a/src/request.test.js
+++ b/src/request.test.js
@@ -15,27 +15,19 @@ const responses = {
     }
   },
   success: {
-    bundle: {
-      file: 'files/export/796277985a61b2cdc3bd15.32504586/1523613069/Sample_Project-intl.zip',
-      full_file: 'https://s3-eu-west-1.amazonaws.com/lokalise-assets/files/export/796277985a61b2cdc3bd15.32504586/1523613069/Sample_Project-intl.zip'
-    },
-    response: {
-      status: 'success',
-      code: '200',
-      message: 'OK'
-    }
+    project_id: projectId,
+    bundle_url: 'https://s3-eu-west-1.amazonaws.com/lokalise-assets/files/export/796277985a61b2cdc3bd15.32504586/1523613069/Sample_Project-intl.zip'
   }
 }
 
 const mockTransaction = () => (
-  nock('https://lokalise.co')
-    .post('/api/project/export', {
-      api_token: apiToken,
-      id: projectId,
-      type: 'json',
-      bundle_filename: '%PROJECT_NAME%-intl.zip',
-      bundle_structure: '%LANG_ISO%.%FORMAT%'
-    })
+  nock(`https://api.lokalise.com/api2/projects/${projectId}`, {
+    reqheaders: {
+      'x-api-token': apiToken,
+      'content-type': 'application/json'
+    }
+  })
+  .post(`/files/download`, )
 )
 
 describe('request', () => {
@@ -53,7 +45,7 @@ describe('request', () => {
       expect.assertions(1)
       mockTransaction().reply(200, responses.success)
 
-      await expect(request.bundle(apiToken, projectId)).resolves.toEqual(responses.success.bundle.file)
+      await expect(request.bundle(apiToken, projectId)).resolves.toEqual(responses.success.bundle_url)
     })
 
     it('throws on a non 200 status response', async () => {

--- a/src/request.test.js
+++ b/src/request.test.js
@@ -27,7 +27,7 @@ const mockTransaction = () => (
       'content-type': 'application/json'
     }
   })
-  .post(`/files/download`, )
+    .post(`/files/download`)
 )
 
 describe('request', () => {


### PR DESCRIPTION
Lokalise changed deprecated `export` endpoint and now they use `/download`

PR also includes:
- Adding `CONTRIBUTING.md`
- Updating `README.md`
- Adding `.editorconfig`